### PR TITLE
First-pass cosmetic changes.

### DIFF
--- a/src/add_registration.html
+++ b/src/add_registration.html
@@ -6,6 +6,22 @@
             footer {
                 margin-top: 20px;
             }
+
+            body {
+                font-family: sans-serif;
+                font-size: 14px;
+                background-color: #fff9eb; /* beige */
+                color: #362e1b; /* brown */
+                margin: 0 18px 18px 18px;
+                line-height: 1.75em;
+            }
+            h1 {
+                text-align: center;
+                color: #362e1b; /* brown */  
+            }
+            a {
+                color: #04606e; /* blue */
+            }
         </style>
     </head>
     <body>

--- a/src/popup.html
+++ b/src/popup.html
@@ -8,10 +8,22 @@
                 font-size: 14px;
                 width: 400px;
                 box-sizing: border-box;
+                background-color: #fff9eb; /* beige */
+                color: #362e1b; /* brown */
+                margin: 0 18px 18px 18px;
+                line-height: 1.75em;
             }
             #entries {
                 list-style: circle;
                 padding-left: 0;
+            }
+            h1 {
+                text-align: center;
+                color: #362e1b; /* brown */
+            }
+            a {
+                color: #04606e; /* blue */
+                /*text-decoration: none;*/
             }
         </style>
     </head>
@@ -71,8 +83,8 @@
             </span>
         </div>
         <div>
-            <a id="add-registration" href="#add-registration">
-                [+] <span>add registration</span></a>
+            [+] <a id="add-registration" href="#add-registration">
+                <span>Add registration</span></a>
         </div>
         <footer>
             <a id="footer-link" href="https://github.com/open-austin/purge-alert" target="_blank">Purge Alert</a>


### PR DESCRIPTION
First-pass cosmetic changes:
* Changed background color from white to beige
* Changed text color from black to dark brown
* Changed link text color to from default blue to retro blue
* Increased text size
* Converted `[+]` in `add registration` link to nonlink

<img width="437" alt="Screen Shot 2020-02-19 at 9 06 26 AM" src="https://user-images.githubusercontent.com/6895034/74847096-30f53f00-52f7-11ea-9d6a-9d8e3eeec827.png">

<img width="498" alt="Screen Shot 2020-02-19 at 9 06 43 AM" src="https://user-images.githubusercontent.com/6895034/74847103-32bf0280-52f7-11ea-99aa-d936e3520334.png">
